### PR TITLE
autoresize window on play

### DIFF
--- a/renderer/index.js
+++ b/renderer/index.js
@@ -85,7 +85,6 @@ function init () {
   })
 
   document.addEventListener('keydown', function (e) {
-    console.log('keydown ' + e.which)
     if (e.which === 27) { /* ESC means either exit fullscreen or go back */
       if (state.view.isFullScreen) {
         dispatch('toggleFullScreen')

--- a/renderer/views/player.js
+++ b/renderer/views/player.js
@@ -30,7 +30,7 @@ function Player (state, dispatch) {
       <div class="letterbox">
         <video
           src="${state.server.localURL}"
-          onloadedmetadata="${onLoadedMetadata}"
+          onloadedmetadata=${onLoadedMetadata}
           autoplay="true">
         </video>
       </div>
@@ -79,7 +79,6 @@ function renderPlayerControls (state, dispatch) {
   if (state.view.devices.chromecast) {
     elements.push(hx`
       <i.icon.chromecast
-        class="${!torrent.ready ? 'disabled' : ''}"
         onclick=${() => dispatch('openChromecast', torrent)}>
         cast
       </i>
@@ -88,7 +87,6 @@ function renderPlayerControls (state, dispatch) {
   if (state.view.devices.airplay) {
     elements.push(hx`
       <i.icon.airplay
-        class="${!torrent.ready ? 'disabled' : ''}"
         onclick=${() => dispatch('openAirplay', torrent)}>
         airplay
       </i>
@@ -96,7 +94,7 @@ function renderPlayerControls (state, dispatch) {
   }
   // On OSX, the back button is in the title bar of the window; see app.js
   // On other platforms, we render one over the video on mouseover
-  if(process.platform !== 'darwin') {
+  if (process.platform !== 'darwin') {
     elements.push(hx`
       <i.icon.back
         onclick=${() => dispatch('back')}>


### PR DESCRIPTION
function references in hyperx need to look like:

```
onloadedmetadata=${onLoadedMetadata}
```

and not:

```
onloadedmetadata="${onLoadedMetadata}"
```

also removed some unnecessary `torrent.ready` checks in the player.

> fixes #17 