### PR TITLE
improve torrent metadata display

### DIFF
--- a/renderer/index.css
+++ b/renderer/index.css
@@ -266,7 +266,7 @@ body.drag::before {
   bottom: 20px;
 }
 
-.torrent .status :not(:last-child)::after {
+.torrent span:not(:last-child)::after {
   content: ' — ';
 }
 

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -72,7 +72,7 @@ function init () {
   dragDrop('body', onFiles)
 
   chromecasts.on('update', function (player) {
-    state.view.chromecast = player
+    state.view.devices.chromecast = player
     update()
   })
 
@@ -285,8 +285,8 @@ function deleteTorrent (torrent) {
 
 function openChromecast (torrent) {
   startServer(torrent, function () {
-    state.view.chromecast.play(state.server.networkURL, { title: 'WebTorrent — ' + torrent.name })
-    state.view.chromecast.on('error', function (err) {
+    state.view.devices.chromecast.play(state.server.networkURL, { title: 'WebTorrent — ' + torrent.name })
+    state.view.devices.chromecast.on('error', function (err) {
       err.message = 'Chromecast: ' + err.message
       onError(err)
     })

--- a/renderer/views/torrent-list.js
+++ b/renderer/views/torrent-list.js
@@ -49,13 +49,12 @@ function renderTorrent (state, dispatch, torrent) {
 
 // Renders the torrent name and download progress
 function renderTorrentMetadata (torrent) {
-  var progress = Math.floor(100 * torrent.progress)
   return hx`
     <div class="metadata">
       <div class="name ellipsis">${torrent.name || 'Loading torrent...'}</div>
       <div class="status">
-        <span class="progress">${progress}%</span>
-        <span>${prettyBytes((torrent.length / 100) * progress)} / ${prettyBytes(torrent.length)}</span>
+        <span class="progress">${Math.floor(100 * torrent.progress)}%</span>
+        <span>${prettyBytes(torrent.length * torrent.progress)} / ${prettyBytes(torrent.length)}</span>
       </div>
       ${getFilesLength()}
       <span>${getPeers()}</span>

--- a/renderer/views/torrent-list.js
+++ b/renderer/views/torrent-list.js
@@ -49,17 +49,28 @@ function renderTorrent (state, dispatch, torrent) {
 
 // Renders the torrent name and download progress
 function renderTorrentMetadata (torrent) {
+  var progressPercent = 0
+  var progressBytes = 0
+
+  if (torrent.progress) {
+    progressPercent = Math.floor(100 * torrent.progress)
+  }
+
+  if (torrent.length && torrent.progress) {
+    progressBytes = torrent.length * torrent.progress
+  }
+
   return hx`
     <div class="metadata">
       <div class="name ellipsis">${torrent.name || 'Loading torrent...'}</div>
       <div class="status">
-        <span class="progress">${Math.floor(100 * torrent.progress)}%</span>
-        <span>${prettyBytes(torrent.length * torrent.progress)} / ${prettyBytes(torrent.length)}</span>
+        <span class="progress">${progressPercent}%</span>
+        <span>${prettyBytes(progressBytes)} / ${prettyBytes(torrent.length || 0)}</span>
       </div>
       ${getFilesLength()}
       <span>${getPeers()}</span>
-      <span>↓ ${prettyBytes(torrent.downloadSpeed)}/s</span>
-      <span>↑ ${prettyBytes(torrent.uploadSpeed)}/s</span>
+      <span>↓ ${prettyBytes(torrent.downloadSpeed || 0)}/s</span>
+      <span>↑ ${prettyBytes(torrent.uploadSpeed || 0)}/s</span>
     </div>
   `
 

--- a/renderer/views/torrent-list.js
+++ b/renderer/views/torrent-list.js
@@ -49,16 +49,18 @@ function renderTorrent (state, dispatch, torrent) {
 
 // Renders the torrent name and download progress
 function renderTorrentMetadata (torrent) {
+  var progress = Math.floor(100 * torrent.progress)
   return hx`
     <div class="metadata">
       <div class="name ellipsis">${torrent.name || 'Loading torrent...'}</div>
       <div class="status">
-        <span class="progress">${Math.floor(100 * torrent.progress)}%</span>
+        <span class="progress">${progress}%</span>
+        <span>${prettyBytes((torrent.length / 100) * progress)} / ${prettyBytes(torrent.length)}</span>
       </div>
       ${getFilesLength()}
       <span>${getPeers()}</span>
-      <span>${prettyBytes(torrent.downloadSpeed)}/s</span>
-      <span>${prettyBytes(torrent.uploadSpeed)}/s</span>
+      <span>↓ ${prettyBytes(torrent.downloadSpeed)}/s</span>
+      <span>↑ ${prettyBytes(torrent.uploadSpeed)}/s</span>
     </div>
   `
 


### PR DESCRIPTION
Now it's a little clearer which speed is upload and which is download, and you can also see total size and total downloaded in bytes so far.

![screen shot 2016-03-05 at 10 43 26 am](https://cloud.githubusercontent.com/assets/427322/13549696/417569c8-e2c0-11e5-9318-d9eab683a3ab.png)
