### PR TITLE
Batch virtual-dom changes (fix #27)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "debug": "^2.2.0",
     "drag-drop": "^2.3.1",
     "hyperx": "^2.0.0",
+    "main-loop": "^3.2.0",
     "network-address": "^1.1.0",
     "pretty-bytes": "^3.0.0",
     "throttleit": "^1.0.0",


### PR DESCRIPTION
From `main-loop`:

> main-loop is an optimization module for a virtual DOM system.
Normally you would re-create the virtual tree every time your state
changes. This is not optimum, with main-loop you will only update your
virtual tree at most once per request animation frame.

> main-loop basically gives you batching of your virtual DOM changes,
which means if you change your model multiple times it will be rendered
once asynchronously on the next request animation frame.