### PR TITLE
Add alternate fullscreen shortcut ⌘+Shift+F (fix #26)

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -4,6 +4,7 @@ var electron = require('electron')
 var ipc = require('./ipc')
 var menu = require('./menu')
 var windows = require('./windows')
+var shortcuts = require('./shortcuts')
 
 var app = electron.app
 
@@ -15,6 +16,7 @@ app.on('open-url', onOpen)
 app.on('ready', function () {
   electron.Menu.setApplicationMenu(menu.appMenu)
   windows.createMainWindow(menu)
+  shortcuts.init(menu)
 })
 
 app.on('activate', function () {

--- a/main/ipc.js
+++ b/main/ipc.js
@@ -1,11 +1,11 @@
+module.exports = {
+  init: init
+}
+
 var electron = require('electron')
 var debug = require('debug')('webtorrent-app:ipcMain')
 var ipcMain = electron.ipcMain
 var windows = require('./windows')
-
-module.exports = {
-  init: init
-}
 
 function init () {
   ipcMain.on('addTorrentFromPaste', function (e) {

--- a/main/menu.js
+++ b/main/menu.js
@@ -18,7 +18,7 @@ function onWindowHide () {
 
 function toggleFullScreen () {
   debug('toggleFullScreen')
-  if (windows.main) {
+  if (windows.main && windows.main.isVisible()) {
     windows.main.setFullScreen(!windows.main.isFullScreen())
   }
 }
@@ -289,7 +289,8 @@ var menu = {
   appMenu: appMenu,
   onToggleFullScreen: onToggleFullScreen,
   onWindowHide: onWindowHide,
-  onWindowShow: onWindowShow
+  onWindowShow: onWindowShow,
+  toggleFullScreen: toggleFullScreen
 }
 
 module.exports = menu

--- a/main/shortcuts.js
+++ b/main/shortcuts.js
@@ -2,7 +2,6 @@ module.exports = {
   init: init
 }
 
-var electron = require('electron')
 var localShortcut = require('electron-localshortcut')
 
 function init (menu) {

--- a/main/shortcuts.js
+++ b/main/shortcuts.js
@@ -1,0 +1,13 @@
+module.exports = {
+  init: init
+}
+
+var electron = require('electron')
+var localShortcut = require('electron-localshortcut')
+
+function init (menu) {
+  // ⌘+Shift+F is an alternative fullscreen shortcut to the one defined in menu.js.
+  // Electron does not support multiple accelerators for a single menu item, so this
+  // is registered separately here.
+  localShortcut.register('CmdOrCtrl+Shift+F', menu.toggleFullScreen)
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "create-torrent": "^3.22.1",
     "debug": "^2.2.0",
     "drag-drop": "^2.3.1",
+    "electron-localshortcut": "^0.6.0",
     "hyperx": "^2.0.0",
     "main-loop": "^3.2.0",
     "network-address": "^1.1.0",


### PR DESCRIPTION
Uses https://npmjs.com/package/electron-localshortcut to workaround a
bug in Electron (https://github.com/atom/electron/issues/1334).

We can remove `electron-localshortcut` once that bug is fixed.