### PR TITLE
Fullscreen fixes

### DIFF
--- a/main/ipc.js
+++ b/main/ipc.js
@@ -45,7 +45,7 @@ function addTorrentFromPaste () {
 
 function setBounds (bounds) {
   debug('setBounds %o', bounds)
-  if (windows.main) {
+  if (windows.main && !windows.main.isFullScreen()) {
     windows.main.setBounds(bounds, true)
   }
 }

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -350,8 +350,6 @@ function openAirplay (torrent) {
 }
 
 function setDimensions (dimensions) {
-  if (state.isFullScreen) return
-
   state.mainWindowBounds = electron.remote.getCurrentWindow().getBounds()
 
   // Limit window size to screen size

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -350,6 +350,8 @@ function openAirplay (torrent) {
 }
 
 function setDimensions (dimensions) {
+  if (state.isFullScreen) return
+
   state.mainWindowBounds = electron.remote.getCurrentWindow().getBounds()
 
   // Limit window size to screen size

--- a/renderer/views/app.js
+++ b/renderer/views/app.js
@@ -8,7 +8,23 @@ var Header = require('./header')
 var Player = require('./player')
 var TorrentList = require('./torrent-list')
 
+var isOSX = process.platform === 'darwin'
+
 function App (state, dispatch) {
+  return hx`
+    <div class='app'>
+      ${getHeader()}
+      <div class='content'>${getView()}</div>
+    </div>
+  `
+
+  function getHeader () {
+    // Hide the header on Windows/Linux when in the player
+    if (isOSX || state.url !== '/player') {
+      return Header(state, dispatch)
+    }
+  }
+
   function getView () {
     if (state.url === '/') {
       return TorrentList(state, dispatch)
@@ -16,18 +32,4 @@ function App (state, dispatch) {
       return Player(state, dispatch)
     }
   }
-
-  // Show the header only when we're outside of fullscreen
-  // Also don't show it in the video player except in OSX
-  var isOSX = process.platform === 'darwin'
-  var isVideo = state.url === '/player'
-  var isFullScreen = state.isFullScreen
-  var header = !isFullScreen && (!isVideo || isOSX) ? Header(state, dispatch) : null
-
-  return hx`
-    <div class="app">
-      ${header}
-      <div class="content">${getView()}</div>
-    </div>
-  `
 }


### PR DESCRIPTION
This change does the following:

- Prevent the window from resizing when in fullscreen because that just behaves weirdly.
- Show the header on Linux/Windows when fullscreened, but not in the
player. Users might fullscreen the app when they’re not playing a video.
- Always show the header on OS X (even when fullscreened) since that’s
how the user will exit the video. We can work on adding auto-hiding to
it later.