### PR TITLE
improve progress percent & bytes display

### DIFF
--- a/renderer/views/torrent-list.js
+++ b/renderer/views/torrent-list.js
@@ -45,23 +45,18 @@ function renderTorrent (torrent, dispatch) {
 
 // Renders the torrent name and download progress
 function renderTorrentMetadata (torrent) {
-  var progressPercent = 0
-  var progressBytes = 0
+  var progress = Math.floor(100 * (torrent.progress || 0))
+  var downloaded = prettyBytes(torrent.downloaded || 0)
+  var total = prettyBytes(torrent.length || 0)
 
-  if (torrent.progress) {
-    progressPercent = Math.floor(100 * torrent.progress)
-  }
-
-  if (torrent.length && torrent.progress) {
-    progressBytes = torrent.length * torrent.progress
-  }
+  if (downloaded !== total) downloaded += ` / ${total}`
 
   return hx`
     <div class="metadata">
       <div class="name ellipsis">${torrent.name || 'Loading torrent...'}</div>
       <div class="status">
-        <span class="progress">${progressPercent}%</span>
-        <span>${prettyBytes(progressBytes)} / ${prettyBytes(torrent.length || 0)}</span>
+        <span class="progress">${progress}%</span>
+        <span>${downloaded}</span>
       </div>
       ${getFilesLength()}
       <span>${getPeers()}</span>


### PR DESCRIPTION
Tiny adjustment for progress bytes.

Ensures that at 0 or 100%, progress will not show duplicate values. So no `0 B / 0 B` or `129.4 MB / 129.4 MB`. Instead it looks like this:

![screen shot 2016-03-05 at 6 43 16 pm](https://cloud.githubusercontent.com/assets/427322/13551985/2388fb54-e302-11e5-946e-7bc2ac5db1f2.png)
