### PR TITLE
add persistent app config

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "airplay-js": "guerrerocarlos/node-airplay-js",
+    "application-config": "^0.2.0",
     "chromecasts": "^1.8.0",
     "create-torrent": "^3.22.1",
     "debug": "^2.2.0",

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -315,7 +315,7 @@ function openPlayer (torrent) {
 }
 
 function deleteTorrent (torrent) {
-  torrent.destroy(function() {
+  torrent.destroy(function () {
     saveTorrents() // updates after writing to config
   })
 }

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -315,7 +315,9 @@ function openPlayer (torrent) {
 }
 
 function deleteTorrent (torrent) {
-  torrent.destroy(update)
+  torrent.destroy(function() {
+    saveTorrents() // updates after writing to config
+  })
 }
 
 function openChromecast (torrent) {

--- a/renderer/state.js
+++ b/renderer/state.js
@@ -27,27 +27,20 @@ module.exports = {
     mouseStationarySince: 0 /* Unix time in ms */
   },
 
-  /* Saved state is read from and written to ~/.webtorrent/state.json
-   * It should be simple and minimal and must be JSONifiable
+  /* Saved state is read from and written to application config.
+   * It should be simple and minimal and must be JSON stringifiable.
+   *
+   * Config path:
+   *
+   * OS XDG               ~/Library/Application Support/WebTorrent/config.json
+   * Linux (XDG)          $XDG_CONFIG_HOME/WebTorrent/config.json
+   * Linux (Legacy)       ~/.config/WebTorrent/config.json
+   * Windows (> Vista)    %LOCALAPPDATA%/WebTorrent/config.json
+   * Windows (XP, 2000)   %USERPROFILE%/Local Settings/Application Data/WebTorrent/config.json
+   *
+   * Also accessible via `require('application-config')('WebTorrent').filePath`
    */
   saved: {
-    torrents: [
-      {
-        name: 'Sintel',
-        torrentFile: 'resources/sintel.torrent'
-      }
-      // {
-      //   name: 'Elephants Dream',
-      //   torrentFile: 'resources/ElephantsDream_archive.torrent'
-      // },
-      // {
-      //   name: 'Big Buck Bunny',
-      //   torrentFile: 'resources/BigBuckBunny_archive.torrent'
-      // },
-      // {
-      //   name: 'Tears of Steel',
-      //   torrentFile: 'resources/TearsOfSteel_archive.torrent'
-      // }
-    ]
+    torrents: []
   }
 }


### PR DESCRIPTION
Using `application-config` for now. So far working great. Storing magnet URIs of torrents in config instead of `.torrent` file paths since those are often deleted.

Played around with some different ways to capture and save torrent info until I realized I could just save info from `state.client.map` with the props I wanted on every client `torrent` event. That way no deduping is necessary. The WebTorrent client always tells the truth.

> resolves #24