### PR TITLE
Save and load torrents, document index.js

### DIFF
--- a/renderer/state.js
+++ b/renderer/state.js
@@ -27,8 +27,8 @@ module.exports = {
     mouseStationarySince: 0 /* Unix time in ms */
   },
 
-  /* Saved state is read from and written to application config.
-   * It should be simple and minimal and must be JSON stringifiable.
+  /* Saved state is read from and written to a file every time the app runs.
+   * It should be simple and minimal and must be JSON.
    *
    * Config path:
    *


### PR DESCRIPTION
### This PR
* Clean up `index.js`
* Separate `state.saved.torrents` from the list of currently active torrents (`state.client.torrents`)
  This prepares us to support torrents which are not currently downloading -- such as the default videos that will show when Webtorrent.app is first installed. Such torrents are in `state.saved.torrents` but not in the active torrents list.

## Next PR
* Make the Blender Foundation videos show up by default
* Add a small Download button next to the big Play button
  This starts / pauses the torrent download. While downloading the Play button will pulsate to show activity. Once the torrent is fully downloaded it will be solid green, to show that we're done and are now seeding. The button will act as a toggle--if you turn it off, it turns grey to indicate that the torrent is not currently torrenting. Pressing play automatically starts the torrent (if it is not already fully DL'd) and starts playing / streaming.