### PR TITLE
load state first

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "pretty-bytes": "^3.0.0",
     "upload-element": "^1.0.1",
     "virtual-dom": "^2.1.1",
-    "webtorrent": "^0.82.1"
+    "webtorrent": "^0.82.1",
+    "xtend": "^4.0.1"
   },
   "devDependencies": {
     "electron-packager": "^5.0.0",


### PR DESCRIPTION
This PR does a few things:

- loads state before initializing app
- wraps IPC setup in a function called by `init()` to avoid a race condition where `update()` gets called too soon
- moves resuming of saved torrents into a function
- removes an unnecessary `console.log`

Loading state first allows setting defaults and preferences first (setup for #53).

Side thought:

Wondering if it might be faster to load app with less going on upfront (just header and empty list initialized) then send saved state over IPC from the main process. Startup is pretty slow for me at this stage and I feel like there's not enough going on in the UI to warrant that.