### PR TITLE
Remove updateThrottled

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "main-loop": "^3.2.0",
     "network-address": "^1.1.0",
     "pretty-bytes": "^3.0.0",
-    "throttleit": "^1.0.0",
     "upload-element": "^1.0.1",
     "virtual-dom": "^2.1.1",
     "webtorrent": "^0.82.1"


### PR DESCRIPTION
`updateThrottled` uses `setTimeout`/`clearTimeout` to ensure `update` is called at most once a second, but then we call `updateThrottle` exactly once a second anyway!

that's equivalent to calling `update` once a second directly