### PR TITLE
Fix Windows UX issues

### DIFF
--- a/main/ipc.js
+++ b/main/ipc.js
@@ -49,7 +49,7 @@ function addTorrentFromPaste () {
 
 function setBounds (bounds) {
   debug('setBounds %o', bounds)
-  if (windows.main && !windows.main.isFullScreen()) {
+  if (windows.main && !windows.main.isFullScreen() && !windows.main.isMaximized()) {
     windows.main.setBounds(bounds, true)
   }
 }

--- a/main/windows.js
+++ b/main/windows.js
@@ -16,6 +16,7 @@ app.on('before-quit', function () {
 
 function createMainWindow (menu) {
   var win = windows.main = new electron.BrowserWindow({
+    autoHideMenuBar: true, // Hide top menu bar unless Alt key is pressed (Windows, Linux)
     backgroundColor: '#282828',
     darkTheme: true,
     minWidth: 375,

--- a/main/windows.js
+++ b/main/windows.js
@@ -18,12 +18,12 @@ function createMainWindow (menu) {
   var win = windows.main = new electron.BrowserWindow({
     autoHideMenuBar: true, // Hide top menu bar unless Alt key is pressed (Windows, Linux)
     backgroundColor: '#282828',
-    darkTheme: true,
+    darkTheme: true, // Forces dark theme (GTK+3 only)
     minWidth: 375,
     minHeight: 158,
-    show: false,
+    show: false, // Hide window until DOM finishes loading
     title: config.APP_NAME,
-    titleBarStyle: 'hidden-inset',
+    titleBarStyle: 'hidden-inset', // Hide OS chrome, except traffic light buttons (OS X)
     width: 450,
     height: 300
   })

--- a/main/windows.js
+++ b/main/windows.js
@@ -33,10 +33,8 @@ function createMainWindow (menu) {
   })
 
   win.webContents.on('did-finish-load', function () {
-    setTimeout(function () {
-      debug('startup time: %sms', Date.now() - app.startTime)
-      win.show()
-    }, 50)
+    debug('startup time: %sms', Date.now() - app.startTime)
+    win.show()
   })
 
   win.on('blur', menu.onWindowHide)

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -163,13 +163,7 @@ function dispatch (action, ...args) {
   if (action === 'back') {
     // TODO
     // window.history.back()
-    if (state.url === '/player') {
-      restoreBounds()
-      closeServer()
-    }
-    state.url = '/'
-    state.title = config.APP_NAME
-    update()
+    closePlayer()
   }
   if (action === 'forward') {
     // TODO
@@ -402,6 +396,17 @@ function openPlayer (torrent) {
     state.title = torrent.name
     update()
   })
+}
+
+function closePlayer () {
+  state.url = '/'
+  state.title = config.APP_NAME
+  if (state.isFullScreen) {
+    electron.ipcRenderer.send('toggleFullScreen')
+  }
+  restoreBounds()
+  closeServer()
+  update()
 }
 
 function deleteTorrent (torrent) {


### PR DESCRIPTION
See my comment here for background: https://github.com/feross/webtorrent-app/issues/3#issuecomment-193559568

- Show window without 50ms timeout (faster startup)
- Hide top menu bar unless Alt key is pressed (Windows, Linux)
- Leave fullscreen when player closes
- Don't resize window if maximized (when player is opened)