### PR TITLE
UI polish (Windows fullscreen, Linux/Windows player window title)

### DIFF
--- a/main/ipc.js
+++ b/main/ipc.js
@@ -32,6 +32,10 @@ function init () {
     windows.main.setFullScreen(!windows.main.isFullScreen())
   })
 
+  ipcMain.on('setTitle', function (e, title) {
+    windows.main.setTitle(title)
+  })
+
   ipcMain.on('log', function (e, message) {
     console.log(message)
   })

--- a/main/ipc.js
+++ b/main/ipc.js
@@ -2,9 +2,10 @@ module.exports = {
   init: init
 }
 
-var electron = require('electron')
 var debug = require('debug')('webtorrent-app:ipcMain')
+var electron = require('electron')
 var ipcMain = electron.ipcMain
+var menu = require('./menu')
 var windows = require('./windows')
 
 function init () {
@@ -28,8 +29,8 @@ function init () {
     setProgress(progress)
   })
 
-  ipcMain.on('toggleFullScreen', function (e) {
-    windows.main.setFullScreen(!windows.main.isFullScreen())
+  ipcMain.on('toggleFullScreen', function (e, flag) {
+    menu.toggleFullScreen(flag)
   })
 
   ipcMain.on('setTitle', function (e, title) {

--- a/main/menu.js
+++ b/main/menu.js
@@ -55,7 +55,6 @@ function onWindowHide () {
   getMenuItem('Float on Top').enabled = false
 }
 
-function onToggleFullScreen () {
 function onToggleFullScreen (isFullScreen) {
   isFullScreen = isFullScreen != null ? isFullScreen : windows.main.isFullScreen()
   windows.main.setMenuBarVisibility(!isFullScreen)

--- a/main/menu.js
+++ b/main/menu.js
@@ -5,19 +5,21 @@ var windows = require('./windows')
 
 var app = electron.app
 
-function toggleFullScreen () {
-  debug('toggleFullScreen')
+function toggleFullScreen (flag) {
+  debug('toggleFullScreen %s', flag)
   if (windows.main && windows.main.isVisible()) {
-    windows.main.setFullScreen(!windows.main.isFullScreen())
+    flag = flag != null ? flag : !windows.main.isFullScreen()
+    windows.main.setFullScreen(flag)
   }
 }
 
 // Sets whether the window should always show on top of other windows
-function toggleFloatOnTop () {
-  debug('toggleFloatOnTop %s')
+function toggleFloatOnTop (flag) {
+  debug('toggleFloatOnTop %s', flag)
   if (windows.main) {
-    windows.main.setAlwaysOnTop(!windows.main.isAlwaysOnTop())
-    getMenuItem('Float on Top').checked = windows.main.isAlwaysOnTop()
+    flag = flag != null ? flag : !windows.main.isAlwaysOnTop()
+    windows.main.setAlwaysOnTop(flag)
+    getMenuItem('Float on Top').checked = flag
   }
 }
 
@@ -37,6 +39,7 @@ function reloadWindow () {
 }
 
 function addFakeDevice (device) {
+  debug('addFakeDevice %s', device)
   windows.main.send('addFakeDevice', device)
 }
 
@@ -53,9 +56,11 @@ function onWindowHide () {
 }
 
 function onToggleFullScreen () {
-  windows.main.setMenuBarVisibility(!windows.main.isFullScreen())
-  getMenuItem('Full Screen').checked = windows.main.isFullScreen()
-  windows.main.send('fullscreenChanged', windows.main.isFullScreen())
+function onToggleFullScreen (isFullScreen) {
+  isFullScreen = isFullScreen != null ? isFullScreen : windows.main.isFullScreen()
+  windows.main.setMenuBarVisibility(!isFullScreen)
+  getMenuItem('Full Screen').checked = isFullScreen
+  windows.main.send('fullscreenChanged', isFullScreen)
 }
 
 function getMenuItem (label) {
@@ -150,12 +155,12 @@ function getMenuTemplate () {
             if (process.platform === 'darwin') return 'Ctrl+Command+F'
             else return 'F11'
           })(),
-          click: toggleFullScreen
+          click: () => toggleFullScreen()
         },
         {
           label: 'Float on Top',
           type: 'checkbox',
-          click: toggleFloatOnTop
+          click: () => toggleFloatOnTop()
         },
         {
           type: 'separator'

--- a/main/windows.js
+++ b/main/windows.js
@@ -42,8 +42,8 @@ function createMainWindow (menu) {
   win.on('blur', menu.onWindowHide)
   win.on('focus', menu.onWindowShow)
 
-  win.on('enter-full-screen', menu.onToggleFullScreen)
-  win.on('leave-full-screen', menu.onToggleFullScreen)
+  win.on('enter-full-screen', () => menu.onToggleFullScreen(true))
+  win.on('leave-full-screen', () => menu.onToggleFullScreen(false))
 
   win.on('close', function (e) {
     if (process.platform === 'darwin' && !isQuitting) {

--- a/main/windows.js
+++ b/main/windows.js
@@ -1,13 +1,14 @@
+var windows = module.exports = {
+  main: null,
+  createMainWindow: createMainWindow
+}
+
 var config = require('../config')
 var debug = require('debug')('webtorrent-app:windows')
 var electron = require('electron')
 
 var app = electron.app
 
-var windows = {
-  main: null,
-  createMainWindow: createMainWindow
-}
 var isQuitting = false
 
 app.on('before-quit', function () {
@@ -55,5 +56,3 @@ function createMainWindow (menu) {
     windows.main = null
   })
 }
-
-module.exports = windows

--- a/renderer/index.css
+++ b/renderer/index.css
@@ -63,7 +63,7 @@ body {
   height: 100%;
   display: flex;
   flex-flow: column;
-  animation: fadein 1s;
+  animation: fadein 0.3s;
 }
 
 /*

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -1,4 +1,5 @@
 console.time('init')
+
 var airplay = require('airplay-js')
 var cfg = require('application-config')('WebTorrent')
 var cfgDirectory = require('application-config-path')('WebTorrent')
@@ -9,6 +10,7 @@ var dragDrop = require('drag-drop')
 var electron = require('electron')
 var EventEmitter = require('events')
 var fs = require('fs')
+var ipcRenderer = electron.ipcRenderer
 var mainLoop = require('main-loop')
 var networkAddress = require('network-address')
 var path = require('path')
@@ -84,7 +86,7 @@ function init () {
 
   // ...same thing if you paste a torrent
   document.addEventListener('paste', function () {
-    electron.ipcRenderer.send('addTorrentFromPaste')
+    ipcRenderer.send('addTorrentFromPaste')
   })
 
   // ...keyboard shortcuts
@@ -103,7 +105,7 @@ function init () {
   // ...focus and blur. Needed to show correct dock icon text ("badge") in OSX
   window.addEventListener('focus', function () {
     state.isFocused = true
-    if (state.dock.badge > 0) electron.ipcRenderer.send('setBadge', '')
+    if (state.dock.badge > 0) ipcRenderer.send('setBadge', '')
     state.dock.badge = 0
   })
 
@@ -175,7 +177,7 @@ function dispatch (action, ...args) {
     update()
   }
   if (action === 'toggleFullScreen') {
-    electron.ipcRenderer.send('toggleFullScreen')
+    ipcRenderer.send('toggleFullScreen')
     update()
   }
   if (action === 'videoMouseMoved') {
@@ -185,20 +187,20 @@ function dispatch (action, ...args) {
 }
 
 function setupIpc () {
-  electron.ipcRenderer.on('addTorrent', function (e, torrentId) {
+  ipcRenderer.on('addTorrent', function (e, torrentId) {
     dispatch('addTorrent', torrentId)
   })
 
-  electron.ipcRenderer.on('seed', function (e, files) {
+  ipcRenderer.on('seed', function (e, files) {
     dispatch('seed', files)
   })
 
-  electron.ipcRenderer.on('fullscreenChanged', function (e, isFullScreen) {
+  ipcRenderer.on('fullscreenChanged', function (e, isFullScreen) {
     state.isFullScreen = isFullScreen
     update()
   })
 
-  electron.ipcRenderer.on('addFakeDevice', function (e, device) {
+  ipcRenderer.on('addFakeDevice', function (e, device) {
     var player = new EventEmitter()
     player.play = (networkURL) => console.log(networkURL)
     state.devices[device] = player
@@ -220,7 +222,7 @@ function detectDevices () {
 function loadState (callback) {
   cfg.read(function (err, data) {
     if (err) console.error(err)
-    electron.ipcRenderer.send('log', 'loaded state from ' + cfg.filePath)
+    ipcRenderer.send('log', 'loaded state from ' + cfg.filePath)
 
     // populate defaults if they're not there
     state.saved = Object.assign({}, state.defaultSavedState, data)
@@ -238,7 +240,7 @@ function resumeTorrents () {
 
 // Write state.saved to the JSON state file
 function saveState () {
-  electron.ipcRenderer.send('log', 'saving state to ' + cfg.filePath)
+  ipcRenderer.send('log', 'saving state to ' + cfg.filePath)
   cfg.write(state.saved, function (err) {
     if (err) console.error(err)
     update()
@@ -256,7 +258,7 @@ function updateDockIcon () {
   }
   if (progress !== state.dock.progress) {
     state.dock.progress = progress
-    electron.ipcRenderer.send('setProgress', progress)
+    ipcRenderer.send('setProgress', progress)
   }
 }
 
@@ -365,7 +367,7 @@ function addTorrentEvents (torrent) {
 
     if (!state.isFocused) {
       state.dock.badge += 1
-      electron.ipcRenderer.send('setBadge', state.dock.badge)
+      ipcRenderer.send('setBadge', state.dock.badge)
     }
 
     update()
@@ -432,7 +434,7 @@ function closePlayer () {
   state.url = '/'
   state.title = config.APP_NAME
   if (state.isFullScreen) {
-    electron.ipcRenderer.send('toggleFullScreen')
+    ipcRenderer.send('toggleFullScreen')
   }
   restoreBounds()
   stopServer()
@@ -507,14 +509,14 @@ function setDimensions (dimensions) {
   var x = Math.floor((screenWidth - width) / 2)
   var y = Math.floor((screenHeight - height) / 2)
 
-  electron.ipcRenderer.send('setAspectRatio', aspectRatio)
-  electron.ipcRenderer.send('setBounds', {x, y, width, height})
+  ipcRenderer.send('setAspectRatio', aspectRatio)
+  ipcRenderer.send('setBounds', {x, y, width, height})
 }
 
 function restoreBounds () {
-  electron.ipcRenderer.send('setAspectRatio', 0)
+  ipcRenderer.send('setAspectRatio', 0)
   if (state.mainWindowBounds) {
-    electron.ipcRenderer.send('setBounds', state.mainWindowBounds, true)
+    ipcRenderer.send('setBounds', state.mainWindowBounds, true)
   }
 }
 

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -193,7 +193,7 @@ function dispatch (action, ...args) {
     update()
   }
   if (action === 'toggleFullScreen') {
-    ipcRenderer.send('toggleFullScreen')
+    ipcRenderer.send('toggleFullScreen', args[0])
     update()
   }
   if (action === 'videoMouseMoved') {
@@ -448,7 +448,7 @@ function closePlayer () {
   update()
 
   if (state.isFullScreen) {
-    ipcRenderer.send('toggleFullScreen')
+    dispatch('toggleFullScreen', false)
   }
   restoreBounds()
   stopServer()

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -10,18 +10,18 @@ var dragDrop = require('drag-drop')
 var electron = require('electron')
 var EventEmitter = require('events')
 var fs = require('fs')
-var ipcRenderer = electron.ipcRenderer
 var mainLoop = require('main-loop')
 var networkAddress = require('network-address')
 var path = require('path')
 var torrentPoster = require('./lib/torrent-poster')
 var WebTorrent = require('webtorrent')
 
+var App = require('./views/app')
 var createElement = require('virtual-dom/create-element')
 var diff = require('virtual-dom/diff')
 var patch = require('virtual-dom/patch')
 
-var App = require('./views/app')
+var ipcRenderer = electron.ipcRenderer
 
 // For easy debugging in Developer Tools
 var state = global.state = require('./state')

--- a/renderer/state.js
+++ b/renderer/state.js
@@ -31,6 +31,7 @@ module.exports = {
     duration: 1, /* seconds */
     mouseStationarySince: 0 /* Unix time in ms */
   },
+  prev: {}, /* used for state diffing in updateElectron() */
 
   /* Saved state is read from and written to a file every time the app runs.
    * It should be simple and minimal and must be JSON.


### PR DESCRIPTION
- Fix fullscreen behavior on Windows
  - The win.isFullScreen() function takes a second to return the correct value after going into fullscreen, so we should just pass the state manually into onToggleFullScreen().
- Update player window title correctly (to match torrent name) on OSs that use that native OS chrome (Windows, Linux). Before it only worked on OS X.
  - This also moves all the state “diffing” for purposes of updating the app’s window via Electron APIs into one function `updateElectron()`. `state.prev` is used to store the previous values for diffing purposes.
  - This is necessary because there's no `virtual-dom` for the Electron app state like dock progress, window title, etc. We don't want to just keep re-calling these OS system calls every time `update()` is called since that's a lot of work and will add jank.
  - We can probably move this into a module later to make it clearer.