### PR TITLE
switch to prettier-bytes

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "hyperx": "^2.0.2",
     "main-loop": "^3.2.0",
     "network-address": "^1.1.0",
-    "pretty-bytes": "^3.0.0",
+    "prettier-bytes": "^1.0.1",
     "upload-element": "^1.0.1",
     "virtual-dom": "^2.1.1",
     "webtorrent": "^0.82.1",

--- a/renderer/views/torrent-list.js
+++ b/renderer/views/torrent-list.js
@@ -3,16 +3,7 @@ module.exports = TorrentList
 var h = require('virtual-dom/h')
 var hyperx = require('hyperx')
 var hx = hyperx(h)
-var pb = require('pretty-bytes')
-
-function prettyBytes (b) {
-  var pretty = pb(b)
-
-  var ps = pretty.split(/\.| /)
-  // if there is more than one digit to the left of the decimal, chop off the fractional part.
-  if (ps.length > 2 && ps[0].replace('-', '').length > 1) return ps[0] + ' ' + ps[2]
-  return pretty
-}
+var prettyBytes = require('prettier-bytes')
 
 function TorrentList (state, dispatch) {
   var list = state.client.torrents.map((torrent) => renderTorrent(torrent, dispatch))


### PR DESCRIPTION
This switches to use a just-published package `prettier-bytes` which does the same thing.

https://github.com/flet/prettier-bytes

It also cuts the decimals to a single digit per @rom1504's comment in #50

I'll also add @feross @rom1504 and @yoshuawuyts as collaborators/npm publishers in case folks want to tweak it more.