### PR TITLE
Lighter window background; small state changes

### DIFF
--- a/renderer/index.css
+++ b/renderer/index.css
@@ -67,6 +67,11 @@ body {
   display: flex;
   flex-flow: column;
   animation: fadein 0.3s;
+  background: rgb(40, 40, 40);
+}
+
+.app:not(.is-focused) {
+  background: rgb(50, 50, 50);
 }
 
 /*
@@ -157,6 +162,10 @@ a:not(.disabled):hover, i:not(.disabled):hover {
   line-height: 1.5em;
 }
 
+.app:not(.is-focused) .header {
+  background: rgb(50, 50, 50);
+}
+
 .view-player .header {
   opacity: 0.8;
 }
@@ -184,7 +193,7 @@ a:not(.disabled):hover, i:not(.disabled):hover {
   float: left;
 }
 
-.darwin.not-fullscreen .header .nav.left {
+.app.is-darwin:not(.is-fullscreen) .header .nav.left {
   margin-left: 78px;
 }
 

--- a/renderer/index.css
+++ b/renderer/index.css
@@ -161,8 +161,8 @@ a:not(.disabled):hover, i:not(.disabled):hover {
   opacity: 0.8;
 }
 
-.app.hide-video-controls .view-player .header {
-  opacity: 0.8;
+.app.hide-video-controls.view-player .header {
+  opacity: 0;
   cursor: none;
 }
 

--- a/renderer/state.js
+++ b/renderer/state.js
@@ -7,31 +7,33 @@ module.exports = {
   /* Temporary state disappears once the program exits.
    * It can contain complex objects like open connections, etc.
    */
-  url: '/',
   client: null, /* the WebTorrent client */
+  prev: {}, /* used for state diffing in updateElectron() */
   server: null, /* local WebTorrent-to-HTTP server */
-  dock: {
-    badge: 0,
-    progress: 0
-  },
+  torrentPlaying: null, /* the torrent we're streaming. see client.torrents */
+  // history: [], /* track how we got to the current view. enables Back button */
+  // historyIndex: 0,
+  url: '/',
   devices: {
     airplay: null, /* airplay client. finds and manages AppleTVs */
     chromecast: null /* chromecast client. finds and manages Chromecasts */
   },
-  torrentPlaying: null, /* the torrent we're streaming. see client.torrents */
-  // history: [], /* track how we got to the current view. enables Back button */
-  // historyIndex: 0,
-  isFocused: true,
-  isFullScreen: false,
-  mainWindowBounds: null, /* x y width height */
-  title: config.APP_NAME, /* current window title */
+  dock: {
+    badge: 0,
+    progress: 0
+  },
+  window: {
+    bounds: null, /* x y width height */
+    isFocused: true,
+    isFullScreen: false,
+    title: config.APP_NAME /* current window title */
+  },
   video: {
-    isPaused: false,
     currentTime: 0, /* seconds */
     duration: 1, /* seconds */
+    isPaused: false,
     mouseStationarySince: 0 /* Unix time in ms */
   },
-  prev: {}, /* used for state diffing in updateElectron() */
 
   /* Saved state is read from and written to a file every time the app runs.
    * It should be simple and minimal and must be JSON.

--- a/renderer/views/app.js
+++ b/renderer/views/app.js
@@ -22,8 +22,9 @@ function App (state, dispatch) {
     !state.video.isPaused
 
   var cls = [
-    process.platform, /* 'windows', 'linux', or 'darwin' for OSX */
-    state.isFullScreen ? 'fullscreen' : 'not-fullscreen',
+    'is-' + process.platform, /* 'is-darwin' (OS X), 'is-win32' (Windows), 'is-linux' */
+    state.window.isFullScreen ? 'is-fullscreen' : '',
+    state.window.isFocused ? 'is-focused' : '',
     isVideoPlayer ? 'view-player' : '',
     hideControls ? 'hide-video-controls' : ''
   ]

--- a/renderer/views/header.js
+++ b/renderer/views/header.js
@@ -30,7 +30,7 @@ function Header (state, dispatch) {
 
   function getTitle () {
     if (process.platform === 'darwin') {
-      return hx`<div class='title'>${state.title}</div>`
+      return hx`<div class='title'>${state.window.title}</div>`
     }
   }
 


### PR DESCRIPTION
Native windows get lighter when they’re backgrounded so they stand out
less (at least on OS X). Let’s do this too.

Even the Spotify app, which has dozens of developers gets this wrong.
We’re so awesome :)

Also:

- Renamed a bunch of state variables (next time will make separate
commit, sry)
- All window-related variables (e.g. isFullScreen, isFocused, etc.)
live in `state.window` now
- Remove negative class name, use CSS :not() instead