### PR TITLE
Move paste to renderer

### DIFF
--- a/main/ipc.js
+++ b/main/ipc.js
@@ -9,10 +9,6 @@ var menu = require('./menu')
 var windows = require('./windows')
 
 function init () {
-  ipcMain.on('addTorrentFromPaste', function (e) {
-    addTorrentFromPaste()
-  })
-
   ipcMain.on('setBounds', function (e, bounds) {
     setBounds(bounds)
   })
@@ -39,16 +35,6 @@ function init () {
 
   ipcMain.on('log', function (e, message) {
     console.log(message)
-  })
-}
-
-function addTorrentFromPaste () {
-  debug('addTorrentFromPaste')
-  var torrentIds = electron.clipboard.readText().split('\n')
-  torrentIds.forEach(function (torrentId) {
-    torrentId = torrentId.trim()
-    if (torrentId.length === 0) return
-    windows.main.send('addTorrent', torrentId)
   })
 }
 

--- a/main/shortcuts.js
+++ b/main/shortcuts.js
@@ -5,7 +5,7 @@ module.exports = {
 var localShortcut = require('electron-localshortcut')
 
 function init (menu) {
-  // ⌘+Shift+F is an alternative fullscreen shortcut to the one defined in menu.js.
+  // ⌘+Shift+F is an alternative fullscreen shortcut to the ones defined in menu.js.
   // Electron does not support multiple accelerators for a single menu item, so this
   // is registered separately here.
   localShortcut.register('CmdOrCtrl+Shift+F', menu.toggleFullScreen)

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -21,6 +21,7 @@ var createElement = require('virtual-dom/create-element')
 var diff = require('virtual-dom/diff')
 var patch = require('virtual-dom/patch')
 
+var clipboard = electron.clipboard
 var ipcRenderer = electron.ipcRenderer
 
 // For easy debugging in Developer Tools
@@ -88,9 +89,7 @@ function init () {
   dragDrop('body', onFiles)
 
   // ...same thing if you paste a torrent
-  document.addEventListener('paste', function () {
-    ipcRenderer.send('addTorrentFromPaste')
-  })
+  document.addEventListener('paste', onPaste)
 
   // ...keyboard shortcuts
   document.addEventListener('keydown', function (e) {
@@ -286,6 +285,15 @@ function onFiles (files) {
 
   // everything else = seed these files
   dispatch('seed', files.filter(isNotTorrentFile))
+}
+
+function onPaste () {
+  var torrentIds = clipboard.readText().split('\n')
+  torrentIds.forEach(function (torrentId) {
+    torrentId = torrentId.trim()
+    if (torrentId.length === 0) return
+    dispatch('addTorrent', torrentId)
+  })
 }
 
 function isTorrentFile (file) {


### PR DESCRIPTION
The ‘clipboard’ module works in the renderer without using the ’remote’
package. So we can eliminate one IPC call this way :)