### PR TITLE
ensure video is paused before hiding window

### DIFF
--- a/renderer/index.js
+++ b/renderer/index.js
@@ -197,8 +197,14 @@ function dispatch (action, ...args) {
     // window.history.forward()
   }
   if (action === 'pause') {
+    if (state.url !== 'player' || state.video.isPaused) {
+      ipcRenderer.send('paused-video')
+    }
     state.video.isPaused = true
     update()
+  }
+  if (action === 'videoPaused') {
+    ipcRenderer.send('paused-video')
   }
   if (action === 'playPause') {
     state.video.isPaused = !state.video.isPaused

--- a/renderer/views/player.js
+++ b/renderer/views/player.js
@@ -36,6 +36,7 @@ function Player (state, dispatch) {
           ondblclick=${() => dispatch('toggleFullScreen')}
           onloadedmetadata=${onLoadedMetadata}
           onended=${onEnded}
+          onpause=${() => dispatch('videoPaused')}
           autoplay>
         </video>
       </div>


### PR DESCRIPTION
`sendSync` is throwing an error currently as it does not exist.

This PR adds logic to signal the video to stop playing and only hide after we're sure the video is paused. 

Feedback appreciated!