### PR TITLE
Block "Power Saver" mode while video is playing

### DIFF
--- a/main/ipc.js
+++ b/main/ipc.js
@@ -9,6 +9,10 @@ var windows = require('./windows')
 
 var app = electron.app
 var ipcMain = electron.ipcMain
+var powerSaveBlocker = electron.powerSaveBlocker
+
+// has to be a number, not a boolean, and undefined throws an error
+var powerSaveBlocked = 0
 
 function init () {
   ipcMain.on('showOpenTorrentFile', function (e) {
@@ -41,6 +45,16 @@ function init () {
 
   ipcMain.on('log', function (e, message) {
     console.log(message)
+  })
+
+  ipcMain.on('playing-video', function (e) {
+    powerSaveBlocked = powerSaveBlocker.start('prevent-display-sleep')
+  })
+
+  ipcMain.on('paused-video', function (e) {
+    if (powerSaveBlocker.isStarted(powerSaveBlocked)) {
+      powerSaveBlocker.stop(powerSaveBlocked)
+    }
   })
 }
 

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -206,6 +206,9 @@ function dispatch (action, ...args) {
     state.video.isPaused = true
     update()
   }
+  if (action === 'videoPlaying') {
+    ipcRenderer.send('playing-video')
+  }
   if (action === 'videoPaused') {
     ipcRenderer.send('paused-video')
   }

--- a/renderer/views/player.js
+++ b/renderer/views/player.js
@@ -36,6 +36,7 @@ function Player (state, dispatch) {
           ondblclick=${() => dispatch('toggleFullScreen')}
           onloadedmetadata=${onLoadedMetadata}
           onended=${onEnded}
+          onplay=${() => dispatch('videoPlaying')}
           onpause=${() => dispatch('videoPaused')}
           autoplay>
         </video>


### PR DESCRIPTION
Using `video.onplay`, `video.onpause`, `dispatch`, `ipc` messages, and `electron.powerSaveBlocker`. I tested for unexpected errors getting thrown but haven't sat around waiting for the display to go to sleep yet. My belief is that it will Just Work™.

> fix #106