### PR TITLE
Dock icon should accept all file types

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ $ npm run package -- [platform]
 
 Where `[platform]` is `--darwin`, `--linux`, or `--win32`.
 
+To package a Windows app from non-Windows platforms, [Wine](https://www.winehq.org/) needs
+to be installed. On OS X, it is installable via [Homebrew](http://brew.sh/).
+
 ### Code Style
 
 [![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)

--- a/bin/package.js
+++ b/bin/package.js
@@ -156,9 +156,11 @@ function postDarwinism () {
 
   infoPlist['CFBundleDocumentTypes'] = [{
     CFBundleTypeExtensions: [ 'torrent' ],
+    CFBundleTypeIconFile: 'WebTorrentFile.icns',
     CFBundleTypeName: 'BitTorrent Document',
     CFBundleTypeRole: 'Editor',
-    CFBundleTypeIconFile: 'WebTorrentFile.icns'
+    LSHandlerRank: 'Owner',
+    LSItemContentTypes: [ 'org.bittorrent.torrent' ]
   }]
 
   fs.writeFileSync(infoPlistPath, plist.build(infoPlist))

--- a/bin/package.js
+++ b/bin/package.js
@@ -152,7 +152,7 @@ function postDarwinism () {
     'static',
     'WebTorrentFile.icns'
   ])
-  var infoPlist = plist.parse(fs.readFileSync(infoPlistPath).toString())
+  var infoPlist = plist.parse(fs.readFileSync(infoPlistPath, 'utf8'))
 
   infoPlist.CFBundleDocumentTypes = [
     {

--- a/bin/package.js
+++ b/bin/package.js
@@ -172,6 +172,8 @@ function postDarwinism () {
     }
   ]
 
+  infoPlist.NSHumanReadableCopyright = 'Copyright © 2014-2016 The WebTorrent Project'
+
   fs.writeFileSync(infoPlistPath, plist.build(infoPlist))
   cp.execSync(`cp ${webTorrentFileIconPath} ${resourcesPath}`)
 }

--- a/bin/package.js
+++ b/bin/package.js
@@ -154,14 +154,23 @@ function postDarwinism () {
   ])
   var infoPlist = plist.parse(fs.readFileSync(infoPlistPath).toString())
 
-  infoPlist['CFBundleDocumentTypes'] = [{
-    CFBundleTypeExtensions: [ 'torrent' ],
-    CFBundleTypeIconFile: 'WebTorrentFile.icns',
-    CFBundleTypeName: 'BitTorrent Document',
-    CFBundleTypeRole: 'Editor',
-    LSHandlerRank: 'Owner',
-    LSItemContentTypes: [ 'org.bittorrent.torrent' ]
-  }]
+  infoPlist.CFBundleDocumentTypes = [
+    {
+      CFBundleTypeExtensions: [ 'torrent' ],
+      CFBundleTypeIconFile: 'WebTorrentFile.icns',
+      CFBundleTypeName: 'BitTorrent Document',
+      CFBundleTypeRole: 'Editor',
+      LSHandlerRank: 'Owner',
+      LSItemContentTypes: [ 'org.bittorrent.torrent' ]
+    },
+    {
+      CFBundleTypeName: 'Any',
+      CFBundleTypeOSTypes: [ '****' ],
+      CFBundleTypeRole: 'Editor',
+      LSTypeIsPackage: false,
+      LSHandlerRank: 'Owner'
+    }
+  ]
 
   fs.writeFileSync(infoPlistPath, plist.build(infoPlist))
   cp.execSync(`cp ${webTorrentFileIconPath} ${resourcesPath}`)

--- a/main/index.js
+++ b/main/index.js
@@ -42,5 +42,5 @@ ipc.init()
 
 function onOpen (e, torrentId) {
   e.preventDefault()
-  windows.main.send('dispatch', 'addTorrent', torrentId)
+  windows.main.send('dispatch', 'openFiles', torrentId)
 }

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -89,7 +89,7 @@ function init () {
   detectDevices()
 
   // ...drag and drop a torrent or video file to play or seed
-  dragDrop('body', onFiles)
+  dragDrop('body', (files) => dispatch('openFiles', files))
 
   // ...same thing if you paste a torrent
   document.addEventListener('paste', onPaste)
@@ -158,6 +158,9 @@ function updateElectron () {
 function dispatch (action, ...args) {
   if (['videoMouseMoved', 'playbackJump'].indexOf(action) < 0) {
     console.log('dispatch: %s %o', action, args) /* log user interactions, but don't spam */
+  }
+  if (action === 'openFiles') {
+    openFiles(args[0] /* files */)
   }
   if (action === 'addTorrent') {
     addTorrent(args[0] /* torrent */)
@@ -319,14 +322,16 @@ function updateClientProgress () {
   state.dock.progress = progress
 }
 
-function onFiles (files) {
+function openFiles (files) {
+  if (!Array.isArray(files)) files = [ files ]
+
   // .torrent file = start downloading the torrent
   files.filter(isTorrentFile).forEach(function (torrentFile) {
-    dispatch('addTorrent', torrentFile)
+    addTorrent(torrentFile)
   })
 
   // everything else = seed these files
-  dispatch('seed', files.filter(isNotTorrentFile))
+  seed(files.filter(isNotTorrentFile))
 }
 
 function onPaste (e) {
@@ -341,7 +346,8 @@ function onPaste (e) {
 }
 
 function isTorrentFile (file) {
-  var extname = path.extname(file.name).toLowerCase()
+  var name = typeof file === 'string' ? file : file.name
+  var extname = path.extname(name).toLowerCase()
   return extname === '.torrent'
 }
 


### PR DESCRIPTION
- OS X: Dock icon accepts drops of all file types -- seeds non-torrent files (fix #156)
- OS X: Register app as "Owner" of .torrent files (gives app priority for opening .torrent files)
- OS X: Add copyright statement to About window