### PR TITLE
Fix Windows packaging

### DIFF
--- a/bin/package.js
+++ b/bin/package.js
@@ -29,7 +29,8 @@ var all = {
 
   // The build version of the application. Maps to the FileVersion metadata property on
   // Windows, and CFBundleVersion on OS X. We're using the short git hash (e.g. 'e7d837e')
-  'build-version': cp.execSync('git rev-parse --short HEAD').toString().replace('\n', ''),
+  // Windows requires the build version to start with a number :/ so we stick on a prefix
+  'build-version': '0-' + cp.execSync('git rev-parse --short HEAD').toString().replace('\n', ''),
 
   // Pattern which specifies which files to ignore when copying files to create the
   // package(s).
@@ -82,8 +83,8 @@ var win32 = {
     // notices, legal symbols, copyright dates, and so on.
     LegalCopyright: fs.readFileSync(path.join(__dirname, '..', 'LICENSE'), 'utf8'),
 
-    // File description to be presented to users.
-    FileDescription: 'Streaming torrent client',
+    // Name of the program, displayed to users
+    FileDescription: config.APP_NAME,
 
     // Original name of the file, not including a path. This information enables an
     // application to determine whether a file has been renamed by a user. The format of

--- a/renderer/views/torrent-list.js
+++ b/renderer/views/torrent-list.js
@@ -33,7 +33,10 @@ function TorrentList (state, dispatch) {
       var gradient = isSelected
         ? 'linear-gradient(to bottom, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0.4) 100%)'
         : 'linear-gradient(to bottom, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0) 100%)'
-      style['background-image'] = gradient + `, url('${torrentSummary.posterURL}')`
+      // Work around a Chrome bug (reproduced in vanilla Chrome, not just Electron):
+      // Backslashes in URLS in CSS cause bizarre string encoding issues
+      var cleanURL = torrentSummary.posterURL.replace(/\\/g, '/')
+      style.backgroundImage = gradient + `, url('${cleanURL}')`
     }
 
     // Foreground: name of the torrent, basic info like size, play button,


### PR DESCRIPTION
* Work around a Chrome bug by avoiding Windows-specific backslash paths
* Change the name of the program from "Streaming torrent client" to "WebTorrent"

![image](https://cloud.githubusercontent.com/assets/169280/13898048/4fe5a66c-ed83-11e5-95df-503fa4f59e70.png)
