### PR TITLE
Fix Exception when dropping .torrent file onto Dock icon when app is closed

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+console.time('init')
 require('./main')
 
 // report crashes

--- a/main/index.js
+++ b/main/index.js
@@ -1,5 +1,3 @@
-var startTime = Date.now()
-
 var electron = require('electron')
 var ipc = require('./ipc')
 var menu = require('./menu')
@@ -8,17 +6,17 @@ var windows = require('./windows')
 
 var app = electron.app
 
+app.on('open-file', onOpen)
+app.on('open-url', onOpen)
+
+app.ipcReady = false // main window has finished loading and IPC is ready
 app.isQuitting = false
-app.startTime = startTime
 
 app.on('ready', function () {
   menu.init()
   windows.createMainWindow()
   shortcuts.init()
 })
-
-app.on('open-file', onOpen)
-app.on('open-url', onOpen)
 
 app.on('before-quit', function () {
   app.isQuitting = true
@@ -42,5 +40,13 @@ ipc.init()
 
 function onOpen (e, torrentId) {
   e.preventDefault()
-  windows.main.send('dispatch', 'openFiles', torrentId)
+  console.log(app.ipcReady)
+  if (app.ipcReady) {
+    openFiles()
+  } else {
+    app.on('ipcReady', openFiles)
+  }
+  function openFiles () {
+    windows.main.send('dispatch', 'openFiles', torrentId)
+  }
 }

--- a/main/ipc.js
+++ b/main/ipc.js
@@ -4,6 +4,7 @@ module.exports = {
 
 var debug = require('debug')('webtorrent-app:ipcMain')
 var electron = require('electron')
+
 var app = electron.app
 var ipcMain = electron.ipcMain
 var powerSaveBlocker = electron.powerSaveBlocker
@@ -15,6 +16,12 @@ var windows = require('./windows')
 var powerSaveBlockID = 0
 
 function init () {
+  ipcMain.on('ipcReady', function (e) {
+    console.timeEnd('init')
+    app.ipcReady = true
+    app.emit('ipcReady')
+  })
+
   ipcMain.on('showOpenTorrentFile', function (e) {
     menu.showOpenTorrentFile()
   })

--- a/main/menu.js
+++ b/main/menu.js
@@ -7,12 +7,14 @@ module.exports = {
   toggleFullScreen: toggleFullScreen
 }
 
-var config = require('../config')
 var debug = require('debug')('webtorrent-app:menu')
 var electron = require('electron')
-var windows = require('./windows')
 
 var app = electron.app
+
+var config = require('../config')
+var windows = require('./windows')
+
 var appMenu, dockMenu
 
 function init () {
@@ -51,7 +53,6 @@ function toggleDevTools () {
 function reloadWindow () {
   debug('reloadWindow')
   if (windows.main) {
-    app.startTime = Date.now()
     windows.main.webContents.reloadIgnoringCache()
   }
 }

--- a/main/shortcuts.js
+++ b/main/shortcuts.js
@@ -4,10 +4,11 @@ module.exports = {
 
 var electron = require('electron')
 var localShortcut = require('electron-localshortcut')
-var menu = require('./menu')
-var windows = require('./windows')
 
 var globalShortcut = electron.globalShortcut
+
+var menu = require('./menu')
+var windows = require('./windows')
 
 function init () {
   // Special "media key" for play/pause, available on some keyboards

--- a/main/windows.js
+++ b/main/windows.js
@@ -3,19 +3,19 @@ var windows = module.exports = {
   createMainWindow: createMainWindow
 }
 
-var config = require('../config')
-var debug = require('debug')('webtorrent-app:windows')
 var electron = require('electron')
-var ipcMain = electron.ipcMain
-var menu = require('./menu')
 
 var app = electron.app
+var ipcMain = electron.ipcMain
+
+var config = require('../config')
+var menu = require('./menu')
 
 function createMainWindow () {
   var win = windows.main = new electron.BrowserWindow({
     autoHideMenuBar: true, // Hide top menu bar unless Alt key is pressed (Windows, Linux)
     backgroundColor: '#282828',
-    darkTheme: true, // Forces dark theme (GTK+3 only)
+    darkTheme: true, // Forces dark theme (GTK+3)
     icon: config.APP_ICON,
     minWidth: 375,
     minHeight: 38 + (120 * 2), // header height + 2 torrents
@@ -32,7 +32,6 @@ function createMainWindow () {
   })
 
   win.webContents.on('did-finish-load', function () {
-    debug('startup time: %sms', Date.now() - app.startTime)
     win.show()
   })
 

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -246,6 +246,8 @@ function dispatch (action, ...args) {
 }
 
 function setupIpc () {
+  ipcRenderer.send('ipcReady')
+
   ipcRenderer.on('dispatch', function (e, action, ...args) {
     dispatch(action, ...args)
   })


### PR DESCRIPTION
Fixes #154

Also, use `console.time()` to time app startup.