### PR TITLE
Windows: register protocol handler for magnet links

### DIFF
--- a/config.js
+++ b/config.js
@@ -10,6 +10,8 @@ module.exports = {
 
   INDEX: 'file://' + path.join(__dirname, 'renderer', 'index.html'),
 
+  IS_PRODUCTION: isProduction(),
+
   SOUND_ADD: 'file://' + path.join(__dirname, 'static', 'sound', 'add.wav'),
   SOUND_DELETE: 'file://' + path.join(__dirname, 'static', 'sound', 'delete.wav'),
   SOUND_DISABLE: 'file://' + path.join(__dirname, 'static', 'sound', 'disable.wav'),
@@ -18,4 +20,16 @@ module.exports = {
   SOUND_ERROR: 'file://' + path.join(__dirname, 'static', 'sound', 'error.wav'),
   SOUND_PLAY: 'file://' + path.join(__dirname, 'static', 'sound', 'play.wav'),
   SOUND_STARTUP: 'file://' + path.join(__dirname, 'static', 'sound', 'startup.wav')
+}
+
+function isProduction () {
+  if (process.platform === 'darwin') {
+    return !/\/Electron\.app\/Contents\/MacOS\/Electron$/.test(process.execPath)
+  }
+  if (process.platform === 'win32') {
+    return !/\\electron\.exe$/.test(process.execPath)
+  }
+  if (process.platform === 'linux') {
+    // TODO
+  }
 }

--- a/main/index.js
+++ b/main/index.js
@@ -8,6 +8,8 @@ var shortcuts = require('./shortcuts')
 var windows = require('./windows')
 var registerProtocolHandler = require('./register-protocol-handler')
 
+var argv = process.argv.slice(2)
+
 app.on('open-file', onOpen)
 app.on('open-url', onOpen)
 
@@ -19,6 +21,12 @@ app.on('ready', function () {
   windows.createMainWindow()
   shortcuts.init()
   registerProtocolHandler()
+})
+
+app.on('ipcReady', function () {
+  argv.forEach(function (torrentId) {
+    windows.main.send('dispatch', 'onOpen', torrentId)
+  })
 })
 
 app.on('before-quit', function () {
@@ -44,12 +52,8 @@ ipc.init()
 function onOpen (e, torrentId) {
   e.preventDefault()
   if (app.ipcReady) {
-    onReadyOpen()
-  } else {
-    app.on('ipcReady', onReadyOpen)
-  }
-  function onReadyOpen () {
     windows.main.send('dispatch', 'onOpen', torrentId)
-    windows.main.focus()
+  } else {
+    argv.push(torrentId)
   }
 }

--- a/main/index.js
+++ b/main/index.js
@@ -24,6 +24,9 @@ app.on('ready', function () {
 })
 
 app.on('ipcReady', function () {
+  if (argv.length) {
+    windows.main.send('log', 'command line args:', argv)
+  }
   argv.forEach(function (torrentId) {
     windows.main.send('dispatch', 'onOpen', torrentId)
   })

--- a/main/index.js
+++ b/main/index.js
@@ -2,13 +2,14 @@ var electron = require('electron')
 
 var app = electron.app
 
+var config = require('../config')
 var ipc = require('./ipc')
 var menu = require('./menu')
+var registerProtocolHandler = require('./register-protocol-handler')
 var shortcuts = require('./shortcuts')
 var windows = require('./windows')
-var registerProtocolHandler = require('./register-protocol-handler')
 
-var argv = process.argv.slice(2)
+var argv = process.argv.slice(config.IS_PRODUCTION ? 1 : 2)
 
 app.on('open-file', onOpen)
 app.on('open-url', onOpen)
@@ -24,8 +25,9 @@ app.on('ready', function () {
 })
 
 app.on('ipcReady', function () {
+  windows.main.send('log', 'IS_PRODUCTION:', config.IS_PRODUCTION)
   if (argv.length) {
-    windows.main.send('log', 'command line args:', argv)
+    windows.main.send('log', 'command line args:', process.argv)
   }
   argv.forEach(function (torrentId) {
     windows.main.send('dispatch', 'onOpen', torrentId)

--- a/main/index.js
+++ b/main/index.js
@@ -1,10 +1,12 @@
 var electron = require('electron')
+
+var app = electron.app
+
 var ipc = require('./ipc')
 var menu = require('./menu')
 var shortcuts = require('./shortcuts')
 var windows = require('./windows')
-
-var app = electron.app
+var registerProtocolHandler = require('./register-protocol-handler')
 
 app.on('open-file', onOpen)
 app.on('open-url', onOpen)
@@ -16,6 +18,7 @@ app.on('ready', function () {
   menu.init()
   windows.createMainWindow()
   shortcuts.init()
+  registerProtocolHandler()
 })
 
 app.on('before-quit', function () {

--- a/main/ipc.js
+++ b/main/ipc.js
@@ -57,10 +57,6 @@ function init () {
 
   ipcMain.on('blockPowerSave', blockPowerSave)
   ipcMain.on('unblockPowerSave', unblockPowerSave)
-
-  ipcMain.on('log', function (e, message) {
-    console.log(message)
-  })
 }
 
 function setBounds (bounds) {

--- a/main/register-protocol-handler.js
+++ b/main/register-protocol-handler.js
@@ -1,0 +1,26 @@
+module.exports = function () {
+  if (process.platform === 'win32') {
+    registerProtocolHandler('magnet', 'URL:BitTorrent Magnet URL', 'WebTorrent.exe')
+  }
+}
+
+function registerProtocolHandler (protocol, name, command) {
+  var Registry = require('winreg')
+
+  var protocolKey = new Registry({
+    hive: Registry.HKCR, // HKEY_CLASSES_ROOT
+    key: '\\' + protocol
+  })
+  protocolKey.set('', Registry.REG_SZ, name, callback)
+  protocolKey.set('URL Protocol', Registry.REG_SZ, '', callback)
+
+  var commandKey = new Registry({
+    hive: Registry.HKCR,
+    key: '\\' + protocol + '\\shell\\open\\command'
+  })
+  commandKey.set('', Registry.REG_SZ, '"' + command + '" "%1"', callback)
+
+  function callback (err) {
+    if (err) console.error(err.message || err)
+  }
+}

--- a/main/register-protocol-handler.js
+++ b/main/register-protocol-handler.js
@@ -1,10 +1,6 @@
-var electron = require('electron')
-
-var app = electron.app
-
 module.exports = function () {
   if (process.platform === 'win32') {
-    registerProtocolHandler('magnet', 'URL:BitTorrent Magnet URL', app.getPath('exe'))
+    registerProtocolHandler('magnet', 'URL:BitTorrent Magnet URL', process.execPath)
   }
 }
 

--- a/main/register-protocol-handler.js
+++ b/main/register-protocol-handler.js
@@ -8,15 +8,15 @@ function registerProtocolHandler (protocol, name, command) {
   var Registry = require('winreg')
 
   var protocolKey = new Registry({
-    hive: Registry.HKCR, // HKEY_CLASSES_ROOT
-    key: '\\' + protocol
+    hive: Registry.HKCU, // HKEY_CURRENT_USER
+    key: '\\Software\\Classes\\' + protocol
   })
   protocolKey.set('', Registry.REG_SZ, name, callback)
   protocolKey.set('URL Protocol', Registry.REG_SZ, '', callback)
 
   var commandKey = new Registry({
-    hive: Registry.HKCR,
-    key: '\\' + protocol + '\\shell\\open\\command'
+    hive: Registry.HKCU,
+    key: '\\Software\\Classes\\' + protocol + '\\shell\\open\\command'
   })
   commandKey.set('', Registry.REG_SZ, '"' + command + '" "%1"', callback)
 

--- a/main/register-protocol-handler.js
+++ b/main/register-protocol-handler.js
@@ -1,6 +1,10 @@
+var electron = require('electron')
+
+var app = electron.app
+
 module.exports = function () {
   if (process.platform === 'win32') {
-    registerProtocolHandler('magnet', 'URL:BitTorrent Magnet URL', 'WebTorrent.exe')
+    registerProtocolHandler('magnet', 'URL:BitTorrent Magnet URL', app.getPath('exe'))
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "prettier-bytes": "^1.0.1",
     "upload-element": "^1.0.1",
     "virtual-dom": "^2.1.1",
-    "webtorrent": "^0.86.0"
+    "webtorrent": "^0.86.0",
+    "winreg": "^1.0.1"
   },
   "devDependencies": {
     "electron-packager": "^5.0.0",

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -257,9 +257,7 @@ function jumpToTime (time) {
 function setupIpc () {
   ipcRenderer.send('ipcReady')
 
-  ipcRenderer.on('dispatch', function (e, action, ...args) {
-    dispatch(action, ...args)
-  })
+  ipcRenderer.on('dispatch', (e, ...args) => dispatch(...args))
 
   ipcRenderer.on('showOpenTorrentAddress', function (e) {
     state.modal = 'open-torrent-address-modal'
@@ -283,7 +281,7 @@ function setupIpc () {
 function loadState (callback) {
   cfg.read(function (err, data) {
     if (err) console.error(err)
-    ipcRenderer.send('log', 'loaded state from ' + cfg.filePath)
+    console.log('loaded state from ' + cfg.filePath)
 
     // populate defaults if they're not there
     state.saved = Object.assign({}, state.defaultSavedState, data)
@@ -305,7 +303,7 @@ function resumeTorrents () {
 
 // Write state.saved to the JSON state file
 function saveState () {
-  ipcRenderer.send('log', 'saving state to ' + cfg.filePath)
+  console.log('saving state to ' + cfg.filePath)
   cfg.write(state.saved, function (err) {
     if (err) console.error(err)
     update()

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -257,6 +257,8 @@ function jumpToTime (time) {
 function setupIpc () {
   ipcRenderer.send('ipcReady')
 
+  ipcRenderer.on('log', (e, ...args) => console.log(...args))
+
   ipcRenderer.on('dispatch', (e, ...args) => dispatch(...args))
 
   ipcRenderer.on('showOpenTorrentAddress', function (e) {


### PR DESCRIPTION
This is for #77.

This uses [`winreg`](https://www.npmjs.com/package/winreg) to modify the registry. I've used this package before for `webtorrent-cli`, to locate the path to launch VLC. `winreg` is great because it just calls out to the `REG` command line program with `child_process`, so it's pure JavaScript. No native deps. We want to avoid native deps in this app. So far we have none -- let's keep it that way.

Also:

If app is running in “production” (i.e. it has been packaged), then it will be invoked with one less argument.

WebTorrent.exe arguments

vs.

electron.exe /path/to/app arguments

We need to detect this to correctly handle `process.argv` command line arguments.