### PR TITLE
fix hide on hover, always show playback position

### DIFF
--- a/renderer/index.css
+++ b/renderer/index.css
@@ -633,13 +633,13 @@ body.drag .torrent-placeholder span {
 
 .player-controls .playback-cursor {
   position: absolute;
-  top: -8px;
+  top: -3px;
   background-color: #FFF;
-  width: 0;
-  height: 0;
-  border-radius: 0;
-  margin-top: 7px;
-  margin-left: 7px;
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  margin-top: 0;
+  margin-left: 0;
   transition-property: width, height, border-radius, margin-top, margin-left;
   transition-duration: 0.1s;
   transition-timing-function: ease-out;
@@ -673,6 +673,10 @@ body.drag .torrent-placeholder span {
   float: right;
 }
 
+.player-controls .fullscreen {
+  margin-right: 15px;
+}
+
 .player-controls .chromecast,
 .player-controls .airplay {
   font-size: 18px; /* make the cast icons less huge */
@@ -689,11 +693,9 @@ body.drag .torrent-placeholder span {
 }
 
 .player .playback-bar:hover .playback-cursor {
+  top: -8px;
   width: 14px;
   height: 14px;
-  border-radius: 7px;
-  margin-top: 0;
-  margin-left: 0;
 }
 
 /*

--- a/renderer/views/app.js
+++ b/renderer/views/app.js
@@ -21,7 +21,7 @@ function App (state, dispatch) {
     state.video.mouseStationarySince !== 0 &&
     new Date().getTime() - state.video.mouseStationarySince > 2000 &&
     !state.video.isPaused &&
-    state.video.location === 'local'
+    state.playing.location === 'local'
 
   // Hide the header on Windows/Linux when in the player
   // On OSX, the header appears as part of the title bar


### PR DESCRIPTION
- fixed hide on hover (`state.video.location` should be `state.playing.location`)
- showing scrubber without needing to hover on playback bar
- added 5px of margin right to full screen button to even things out a bit

Now hover looks like this (same):
![screen shot 2016-03-19 at 8 51 37 pm](https://cloud.githubusercontent.com/assets/427322/13902756/9540ffae-ee14-11e5-81e1-de6122717fd3.png)

Without hover (playback time is now visible):
![screen shot 2016-03-19 at 8 51 33 pm](https://cloud.githubusercontent.com/assets/427322/13902757/9643e11e-ee14-11e5-8239-45f15df0e0f3.png)

After 2 seconds (controls hide after delay again as they should):
![screen shot 2016-03-19 at 8 54 01 pm](https://cloud.githubusercontent.com/assets/427322/13902760/b93006bc-ee14-11e5-9b68-04ea48f89194.png)
