### PR TITLE
Show, unminimize, and focus window after opening magnet link (fix #210)

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -18,15 +18,11 @@ var shouldQuit = app.makeSingleInstance(function (newArgv) {
 
   if (app.ipcReady) {
     log('Second app instance attempted to open but was prevented')
+    windows.focusMainWindow()
 
     newArgv.forEach(function (torrentId) {
       windows.main.send('dispatch', 'onOpen', torrentId)
     })
-
-    if (windows.main.isMinimized()) {
-      windows.main.restore()
-    }
-    windows.main.focus()
   } else {
     argv.push(...newArgv)
   }
@@ -89,6 +85,12 @@ function onOpen (e, torrentId) {
   e.preventDefault()
   if (app.ipcReady) {
     windows.main.send('dispatch', 'onOpen', torrentId)
+    setTimeout(function () {
+      // Required for magnet links opened from Chrome otherwise the confirmation dialog
+      // that Chrome shows causes Chrome to steal back the focus.
+      // Electron issue: https://github.com/atom/electron/issues/4338
+      windows.focusMainWindow()
+    }, 100)
   } else {
     argv.push(torrentId)
   }

--- a/main/windows.js
+++ b/main/windows.js
@@ -1,6 +1,7 @@
 var windows = module.exports = {
   main: null,
-  createMainWindow: createMainWindow
+  createMainWindow: createMainWindow,
+  focusMainWindow: focusMainWindow
 }
 
 var electron = require('electron')
@@ -51,4 +52,11 @@ function createMainWindow () {
   win.once('closed', function () {
     windows.main = null
   })
+}
+
+function focusMainWindow () {
+  if (windows.main.isMinimized()) {
+    windows.main.restore()
+  }
+  windows.main.show() // shows and gives focus
 }


### PR DESCRIPTION
Requires a workaround for this Electron issue:
https://github.com/atom/electron/issues/4338