### PR TITLE
Keyboard shortcuts: volume shortcuts should be local

### DIFF
--- a/main/ipc.js
+++ b/main/ipc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  init: init
+  init
 }
 
 var debug = require('debug')('webtorrent-app:ipcMain')

--- a/main/ipc.js
+++ b/main/ipc.js
@@ -23,13 +23,8 @@ function init () {
     app.emit('ipcReady')
   })
 
-  ipcMain.on('showOpenTorrentFile', function (e) {
-    menu.showOpenTorrentFile()
-  })
-
-  ipcMain.on('showCreateTorrent', function (e) {
-    menu.showCreateTorrent()
-  })
+  ipcMain.on('showOpenTorrentFile', menu.showOpenTorrentFile)
+  ipcMain.on('showCreateTorrent', menu.showCreateTorrent)
 
   ipcMain.on('setBounds', function (e, bounds, maximize) {
     setBounds(bounds, maximize)
@@ -62,6 +57,9 @@ function init () {
 
   ipcMain.on('blockPowerSave', blockPowerSave)
   ipcMain.on('unblockPowerSave', unblockPowerSave)
+
+  ipcMain.on('onPlayerOpen', menu.onPlayerOpen)
+  ipcMain.on('onPlayerClose', menu.onPlayerClose)
 }
 
 function setBounds (bounds, maximize) {

--- a/main/menu.js
+++ b/main/menu.js
@@ -3,6 +3,8 @@ module.exports = {
   onToggleFullScreen,
   onWindowHide,
   onWindowShow,
+  onPlayerOpen,
+  onPlayerClose,
   showCreateTorrent,
   showOpenTorrentFile,
   toggleFullScreen
@@ -44,6 +46,18 @@ function toggleFloatOnTop (flag) {
   }
 }
 
+function increaseVolume () {
+  if (windows.main) {
+    windows.main.send('dispatch', 'changeVolume', 0.1)
+  }
+}
+
+function decreaseVolume () {
+  if (windows.main) {
+    windows.main.send('dispatch', 'changeVolume', -0.1)
+  }
+}
+
 function toggleDevTools () {
   debug('toggleDevTools')
   if (windows.main) {
@@ -73,6 +87,16 @@ function onWindowHide () {
   debug('onWindowHide')
   getMenuItem('Full Screen').enabled = false
   getMenuItem('Float on Top').enabled = false
+}
+
+function onPlayerOpen () {
+  getMenuItem('Increase Volume').enabled = true
+  getMenuItem('Decrease Volume').enabled = true
+}
+
+function onPlayerClose () {
+  getMenuItem('Increase Volume').enabled = false
+  getMenuItem('Decrease Volume').enabled = false
 }
 
 function onToggleFullScreen (isFullScreen) {
@@ -192,6 +216,21 @@ function getAppMenuTemplate () {
           label: 'Float on Top',
           type: 'checkbox',
           click: () => toggleFloatOnTop()
+        },
+        {
+          type: 'separator'
+        },
+        {
+          label: 'Increase Volume',
+          accelerator: 'CmdOrCtrl+Up',
+          click: increaseVolume,
+          enabled: false
+        },
+        {
+          label: 'Decrease Volume',
+          accelerator: 'CmdOrCtrl+Down',
+          click: decreaseVolume,
+          enabled: false
         },
         {
           type: 'separator'

--- a/main/menu.js
+++ b/main/menu.js
@@ -1,11 +1,11 @@
 module.exports = {
-  init: init,
-  onToggleFullScreen: onToggleFullScreen,
-  onWindowHide: onWindowHide,
-  onWindowShow: onWindowShow,
-  showOpenTorrentFile: showOpenTorrentFile,
-  showCreateTorrent: showCreateTorrent,
-  toggleFullScreen: toggleFullScreen
+  init,
+  onToggleFullScreen,
+  onWindowHide,
+  onWindowShow,
+  showCreateTorrent,
+  showOpenTorrentFile,
+  toggleFullScreen
 }
 
 var debug = require('debug')('webtorrent-app:menu')

--- a/main/shortcuts.js
+++ b/main/shortcuts.js
@@ -1,5 +1,5 @@
 module.exports = {
-  init: init
+  init
 }
 
 var electron = require('electron')

--- a/main/shortcuts.js
+++ b/main/shortcuts.js
@@ -18,8 +18,4 @@ function init () {
   // Electron does not support multiple accelerators for a single menu item, so this
   // is registered separately here.
   localShortcut.register('CmdOrCtrl+Shift+F', menu.toggleFullScreen)
-
-  // Control Volume
-  globalShortcut.register('CmdOrCtrl+Up', () => windows.main.send('dispatch', 'changeVolume', 0.1))
-  globalShortcut.register('CmdOrCtrl+Down', () => windows.main.send('dispatch', 'changeVolume', -0.1))
 }

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -716,8 +716,28 @@ function openPlayer (torrentSummary, index, cb) {
     // otherwise, play the video
     state.window.title = torrentSummary.name
     update()
+
+    ipcRenderer.send('onPlayerOpen')
+
     cb()
   })
+}
+
+function closePlayer (cb) {
+  state.window.title = config.APP_WINDOW_TITLE
+  update()
+
+  if (state.window.isFullScreen) {
+    dispatch('toggleFullScreen', false)
+  }
+  restoreBounds()
+  stopServer()
+  update()
+
+  ipcRenderer.send('unblockPowerSave')
+  ipcRenderer.send('onPlayerClose')
+
+  cb()
 }
 
 function openFile (torrentSummary, index) {
@@ -741,22 +761,6 @@ function openFolder (torrentSummary) {
     }
     ipcRenderer.send('openItem', folderPath)
   })
-}
-
-function closePlayer (cb) {
-  state.window.title = config.APP_WINDOW_TITLE
-  update()
-
-  if (state.window.isFullScreen) {
-    dispatch('toggleFullScreen', false)
-  }
-  restoreBounds()
-  stopServer()
-  update()
-
-  ipcRenderer.send('unblockPowerSave')
-
-  cb()
 }
 
 function toggleTorrent (torrentSummary) {


### PR DESCRIPTION
`globalShortcut` will register the shortcut at the OS level, even when
the app is not focused.

Using `localShortcut` would work, but let's put it in the top menu
instead, where all the other shortcuts are.