### PR TITLE
add binary, fix #247

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+var electron = require('electron-prebuilt')
+var proc = require('child_process')
+var path = require('path')
+
+var child = proc.spawn(electron, [path.join(__dirname, '..')], {stdio: 'inherit'})
+child.on('close', function (code) {
+  process.exit(code)
+})

--- a/bin/package.js
+++ b/bin/package.js
@@ -76,7 +76,7 @@ var all = {
   prune: true,
 
   // The Electron version with which the app is built (without the leading 'v')
-  version: pkg.devDependencies['electron-prebuilt']
+  version: pkg.dependencies['electron-prebuilt']
 }
 
 var darwin = {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "debug": "^2.2.0",
     "drag-drop": "^2.11.0",
     "electron-localshortcut": "^0.6.0",
+    "electron-prebuilt": "0.37.2",
     "hyperx": "^2.0.2",
     "main-loop": "^3.2.0",
     "mkdirp": "^0.5.1",
@@ -34,7 +35,6 @@
   "devDependencies": {
     "electron-osx-sign": "^0.3.0",
     "electron-packager": "^5.0.0",
-    "electron-prebuilt": "0.37.2",
     "electron-winstaller": "^2.0.5",
     "gh-release": "^2.0.3",
     "plist": "^1.2.0",
@@ -64,5 +64,8 @@
     "start": "electron .",
     "test": "standard",
     "update-authors": "./bin/update-authors.sh"
+  },
+  "bin": {
+    "webtorrent-app": "./bin/cmd.js"
   }
 }


### PR DESCRIPTION
cmd.js is mostly taken from node_modules/electron-prebuilt/cli.js (what the node_modules/.bin/electron symlink points to)

I'm not 100% sure what it will do to the package.js though. It might be needed to add some exclude for electron-prebuilt in there.